### PR TITLE
Use packaged model version

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=ref,event=branch
             type=raw,value=latest
             type=semver,pattern={{version}}
 

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install libsndfile1 espeak-ng
+          sudo apt-get install espeak-ng
           python -m pip install --upgrade pip wheel
           pip install -r requirements/requirements.txt -r requirements/test_requirements.txt
       - name: Test TTS

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM python:3.9-slim-bullseye AS compile-image
 
 RUN apt-get update -y && apt-get install -y python3-pip
 
-RUN pip3 install --user torch torchaudio --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install --user torch --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
 
 RUN pip3 install --user neon-tts-plugin-coqui --no-cache-dir
 RUN pip3 install --user ovos-tts-server==0.0.2 --no-cache-dir
 
 FROM python:3.9-slim-bullseye AS build-image
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends libsndfile1 espeak-ng 
+RUN apt-get update -y && apt-get install -y --no-install-recommends espeak-ng 
 COPY --from=compile-image /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ tts:
     }
 ```
 # Requirements:
-`sudo apt install libsndfile1 espeak-ng`
+`sudo apt install espeak-ng`
 
 Necessary for recording audio files
 

--- a/neon_tts_plugin_coqui/__init__.py
+++ b/neon_tts_plugin_coqui/__init__.py
@@ -37,8 +37,6 @@ from ovos_plugin_manager.templates.tts import TTS, TTSValidator
 from ovos_utils.metrics import Stopwatch
 from huggingface_hub import snapshot_download
 from torch import no_grad
-from TTS.utils.manage import ModelManager
-from TTS.utils.synthesizer import Synthesizer
 
 
 class CoquiTTS(TTS):
@@ -71,7 +69,6 @@ class CoquiTTS(TTS):
                                        audio_ext="wav",
                                        ssml_tags=["speak"])
         self.engines = {}
-        self.manager = ModelManager()
         self.cache_engines = self.config.get("cache", True)
         if self.cache_engines:
             self._init_model({"lang": lang})
@@ -128,7 +125,7 @@ class CoquiTTS(TTS):
             return self._audio_to_ipython(wav_data, synthesizer)
 
     @staticmethod
-    def _audio_to_file(wav_data: list, synthesizer: Synthesizer,
+    def _audio_to_file(wav_data: list, synthesizer: object,
                        output_file: str):
         """
         Write synthesized audio to a file
@@ -144,7 +141,7 @@ class CoquiTTS(TTS):
         LOG.debug(f"File access time={stopwatch.time}")
 
     @staticmethod
-    def _audio_to_ipython(wav_data: list, synthesizer: Synthesizer) -> dict:
+    def _audio_to_ipython(wav_data: list, synthesizer: object) -> dict:
         """
         Get a dict representation of synthesized audio for IPython display
         Args:
@@ -169,7 +166,7 @@ class CoquiTTS(TTS):
         libc.malloc_trim(0)
         gc.collect()
 
-    def _init_model(self, speaker: dict) -> (Synthesizer, dict):
+    def _init_model(self, speaker: dict) -> (object, dict):
         """
         Initialize a synthesizer for the specified speaker
         Args:
@@ -198,7 +195,7 @@ class CoquiTTS(TTS):
         LOG.debug(f"RAM={self._get_mem_usage()} MiB")
         return synt, tts_kwargs
 
-    def _init_tts_kwargs(self, lang: str, speaker: dict, synthesizer: Synthesizer) -> dict:
+    def _init_tts_kwargs(self, lang: str, speaker: dict, synthesizer: object) -> dict:
         """
         Parse language and speaker requests into a valid dict of tts kwargs
         Args:
@@ -223,7 +220,7 @@ class CoquiTTS(TTS):
         LOG.debug(f"tts_kwargs={tts_kwargs}")
         return tts_kwargs
 
-    def _init_synthesizer(self, lang: str) -> Synthesizer:
+    def _init_synthesizer(self, lang: str) -> object:
         """
         Create a Synthesizer for the requested language
         Args:

--- a/neon_tts_plugin_coqui/__init__.py
+++ b/neon_tts_plugin_coqui/__init__.py
@@ -46,16 +46,16 @@ class CoquiTTS(TTS):
 
     langs = {
         "en": {
-            "model": "neongeckocom/tts-vits-ljspeech-en@v0.1", 
+            "model": "neongeckocom/tts-vits-ljspeech-en@v0.2", 
         },
         "fr": {
             "model": "neongeckocom/tts-vits-css10-fr@v0.1", 
         },
         "pl": {
-            "model": "neongeckocom/tts-vits-mai-pl@v0.3", 
+            "model": "neongeckocom/tts-vits-mai-pl@v0.4", 
         },
         "uk": {
-            "model": "neongeckocom/tts-vits-mai-uk@v0.6", 
+            "model": "neongeckocom/tts-vits-mai-uk@v0.7", 
         }
     }
 

--- a/neon_tts_plugin_coqui/__init__.py
+++ b/neon_tts_plugin_coqui/__init__.py
@@ -242,38 +242,6 @@ class CoquiTTS(TTS):
                            vocoder_config=vocoder_config_path)
         return synt
 
-    def _download_model(self, model_name: str) -> (str, str):
-        """
-        Download a requested model
-        Args:
-            model_name: Name of model to download
-
-        Returns:
-            tuple model_path, config_path
-        """
-        if model_name is None:
-            return None, None
-            
-        prefix = model_name.split("/")[0]
-        if (prefix == "tts_models") or (prefix == "vocoder_models"):
-            model_path, config_path = self._download_coqui(model_name)
-        else:
-            model_path, config_path = self._download_huggingface(model_name)
-
-        return model_path, config_path
-
-    def _download_coqui(self, model_name) -> (str, str):
-        """
-        Download a model from Coqui
-        Args:
-            model_name: name of model to download
-
-        Returns:
-            tuple model_path, config_path
-        """
-        model_path, config_path, _ = self.manager.download_model(model_name)
-        return model_path, config_path
-
     def _download_huggingface(self, model_name) -> (str, str):
         """
         Download a model from Huggingface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,8 @@
+# TTS
+numpy>=1.19.5
+torch>=1.9
 # dependencies
-TTS == 0.6.2
 ovos-plugin-manager~=0.0.2
+psutil
 # huggingface
 huggingface-hub
-psutil


### PR DESCRIPTION
 - Models stored as solid package
 - `TTS` requirements reduced to `numpy` and `torch`
 - Unlocked `numpy` version
 - Instant model initialization
 - As derived result faster tests pass
 - Added `python 3.10`, deprecated `3.6`