### PR TITLE
Add config entrypoint with supporting data and unit tests

### DIFF
--- a/neon_tts_plugin_coqui/configs.py
+++ b/neon_tts_plugin_coqui/configs.py
@@ -28,103 +28,305 @@
 
 languages = {
     "en": {
-        "model": "neongeckocom/tts-vits-ljspeech-en@v0.4", 
-        "sentence": "A rainbow is a meteorological phenomenon that is caused by reflection, refraction and dispersion of light.",
+        "model": "neongeckocom/tts-vits-ljspeech-en@v0.4",
+        "language": {
+            "name": "English (US)",
+            "code": "en-US",
+            "gender": "female"
+        },
+        "sentence": "A rainbow is a meteorological phenomenon that is caused "
+                    "by reflection, refraction and dispersion of light.",
     },
     "es": {
-        "model": "neongeckocom/tts-vits-css10-es@v0.2", 
-        "sentence": "Un arcoíris o arco iris es un fenómeno óptico y meteorológico que consiste en la aparición en el cielo de un arco de luz multicolor.",
+        "model": "neongeckocom/tts-vits-css10-es@v0.2",
+        "language": {
+            "name": "Spanish (Spain)",
+            "code": "es-ES",
+            "gender": "male"
+        },
+        "sentence": "Un arcoíris o arco iris es un fenómeno óptico y "
+                    "meteorológico que consiste en la aparición en el cielo "
+                    "de un arco de luz multicolor.",
     },
     "fr": {
         "model": "neongeckocom/tts-vits-css10-fr@v0.3", 
-        "sentence": "Un arc-en-ciel est un photométéore, un phénomène optique se produisant dans le ciel, visible dans la direction opposée au Soleil.",
+        "sentence": "Un arc-en-ciel est un photométéore, un phénomène optique "
+                    "se produisant dans le ciel, visible dans la direction "
+                    "opposée au Soleil.",
+        "language": {
+            "name": "French (France)",
+            "code": "fr-FR",
+            "gender": "male"
+        },
     },
     "de": {
         "model": "neongeckocom/tts-vits-css10-de@v0.2", 
-        "sentence": "Der Regenbogen ist ein atmosphärisch-optisches Phänomen, das als kreisbogenförmiges farbiges Lichtband in einer von der Sonne.",
+        "sentence": "Der Regenbogen ist ein atmosphärisch-optisches Phänomen, "
+                    "das als kreisbogenförmiges farbiges Lichtband in einer "
+                    "von der Sonne.",
+        "language": {
+            "name": "German",
+            "code": "de-DE",
+            "gender": "female"
+        },
     },
     "it": {
-        "model": "neongeckocom/tts-vits-cv-it@v0.1", 
-        "sentence": "In fisica dell'atmosfera e meteorologia, l'arcobaleno è un fenomeno ottico atmosferico che produce uno spettro quasi continuo di luce nel cielo quando la luce del Sole attraversa le gocce d'acqua rimaste in sospensione dopo un temporale.",
+        "model": "neongeckocom/tts-vits-cv-it@v0.1",
+        "language": {
+            "name": "Italian",
+            "code": "it-IT",
+            "gender": "female"
+        },
+        "sentence": "In fisica dell'atmosfera e meteorologia, l'arcobaleno è "
+                    "un fenomeno ottico atmosferico che produce uno spettro "
+                    "quasi continuo di luce nel cielo quando la luce del Sole "
+                    "attraversa le gocce d'acqua rimaste in sospensione dopo "
+                    "un temporale.",
     },
     "pl": {
-        "model": "neongeckocom/tts-vits-mai-pl@v0.6", 
-        "sentence": "Tęcza, zjawisko optyczne i meteorologiczne, występujące w postaci charakterystycznego wielobarwnego łuku powstającego w wyniku rozszczepienia światła widzialnego.",
+        "model": "neongeckocom/tts-vits-mai-pl@v0.6",
+        "language": {
+            "name": "Polish",
+            "code": "pl-PO",
+            "gender": "female"
+        },
+        "sentence": "Tęcza, zjawisko optyczne i meteorologiczne, występujące "
+                    "w postaci charakterystycznego wielobarwnego łuku "
+                    "powstającego w wyniku rozszczepienia światła widzialnego.",
     },
     "uk": {
-        "model": "neongeckocom/tts-vits-mai-uk@v0.9", 
-        "sentence": "Веселка, також райдуга оптичне явище в атмосфері, що являє собою одну, дві чи декілька різнокольорових дуг, що спостерігаються на тлі хмари, якщо вона розташована проти Сонця.",
+        "model": "neongeckocom/tts-vits-mai-uk@v0.9",
+        "language": {
+            "name": "Ukrainian",
+            "code": "uk-UA",
+            "gender": "female"
+        },
+        "sentence": "Веселка, також райдуга оптичне явище в атмосфері, що "
+                    "являє собою одну, дві чи декілька різнокольорових дуг, "
+                    "що спостерігаються на тлі хмари, якщо вона розташована "
+                    "проти Сонця.",
     },
     "nl": {
-        "model": "neongeckocom/tts-vits-css10-nl@v0.2", 
-        "sentence": "Een regenboog is een gekleurde cirkelboog die aan de hemel waargenomen kan worden als de, laagstaande.",
+        "model": "neongeckocom/tts-vits-css10-nl@v0.2",
+        "language": {
+            "name": "Dutch",
+            "code": "nl-NL",
+            "gender": "male"
+        },
+        "sentence": "Een regenboog is een gekleurde cirkelboog die aan de "
+                    "hemel waargenomen kan worden als de, laagstaande.",
     },
     "ro": {
-        "model": "neongeckocom/tts-vits-cv-ro@v0.1", 
-        "sentence": "Curcubeul este un fenomen optic și meteorologic atmosferic care se manifestă prin apariția pe cer a unui spectru de forma unui arc colorat atunci când lumina soarelui se refractă în picăturile de apă din atmosferă.", 
+        "model": "neongeckocom/tts-vits-cv-ro@v0.1",
+        "language": {
+            "name": "Romanian",
+            "code": "ro-RO",
+            "gender": "female"
+        },
+        "sentence": "Curcubeul este un fenomen optic și meteorologic "
+                    "atmosferic care se manifestă prin apariția pe cer a unui "
+                    "spectru de forma unui arc colorat atunci când lumina "
+                    "soarelui se refractă în picăturile de apă din atmosferă.",
     },
     "hu": {
-        "model": "neongeckocom/tts-vits-css10-hu@v0.1", 
-        "sentence": "A szivárvány olyan optikai jelenség, melyet eső- vagy páracseppek okoznak, mikor a fény prizmaszerűen megtörik rajtuk és színeire bomlik.", 
+        "model": "neongeckocom/tts-vits-css10-hu@v0.1",
+        "language": {
+            "name": "Hungarian",
+            "code": "hu-HU",
+            "gender": "female"
+        },
+        "sentence": "A szivárvány olyan optikai jelenség, melyet eső- vagy "
+                    "páracseppek okoznak, mikor a fény prizmaszerűen megtörik "
+                    "rajtuk és színeire bomlik.",
     },
     "el": {
-        "model": "neongeckocom/tts-vits-cv-el@v0.1", 
-        "sentence": "Το ουράνιο τόξο εμφανίζεται όταν οι ακτίνες του ήλιου χτυπούν σταγόνες βροχής στην ατμόσφαιρα της Γης και είναι ένα παράδειγμα διάθλασης μετά την ανάκλαση.", 
+        "model": "neongeckocom/tts-vits-cv-el@v0.1",
+        "language": {
+            "name": "Greek",
+            "code": "el-GR",
+            "gender": "female"
+        },
+        "sentence": "Το ουράνιο τόξο εμφανίζεται όταν οι ακτίνες του ήλιου "
+                    "χτυπούν σταγόνες βροχής στην ατμόσφαιρα της Γης και "
+                    "είναι ένα παράδειγμα διάθλασης μετά την ανάκλαση.",
     },
     "cs": {
-        "model": "neongeckocom/tts-vits-cv-cs@v0.1", 
-        "sentence": "Duha je fotometeor, projevující se jako skupina soustředných barevných oblouků, které vznikají lomem a vnitřním odrazem slunečního nebo měsíčního světla na vodních kapkách v atmosféře.", 
+        "model": "neongeckocom/tts-vits-cv-cs@v0.1",
+        "language": {
+            "name": "Czech",
+            "code": "cs-CZ",
+            "gender": "female"
+        },
+        "sentence": "Duha je fotometeor, projevující se jako skupina "
+                    "soustředných barevných oblouků, které vznikají lomem a "
+                    "vnitřním odrazem slunečního nebo měsíčního světla na "
+                    "vodních kapkách v atmosféře.",
     },
     "sv": {
-        "model": "neongeckocom/tts-vits-cv-sv@v0.1", 
-        "sentence": "En regnbåge är ett optiskt, meteorologiskt fenomen som uppträder som ett fullständigt ljusspektrum i form av en båge på himlen då solen lyser på nedfallande regn. Klarast lyser regnbågen då halva himlen fortfarande är täckt med mörka moln som avger regn och betraktaren befinner sig under klar himmel.",
+        "model": "neongeckocom/tts-vits-cv-sv@v0.1",
+        "language": {
+            "name": "Swedish",
+            "code": "sv-SE",
+            "gender": "female"
+        },
+        "sentence": "En regnbåge är ett optiskt, meteorologiskt fenomen som "
+                    "uppträder som ett fullständigt ljusspektrum i form av en "
+                    "båge på himlen då solen lyser på nedfallande regn. "
+                    "Klarast lyser regnbågen då halva himlen fortfarande är "
+                    "täckt med mörka moln som avger regn och betraktaren "
+                    "befinner sig under klar himmel.",
     },
     "pt": {
-        "model": "neongeckocom/tts-vits-cv-pt@v0.1", 
-        "sentence": "Um arco-íris é um fenômeno óptico e meteorológico que separa a luz do sol em seu espectro contínuo quando o sol brilha sobre gotículas de água suspensas no ar.",
+        "model": "neongeckocom/tts-vits-cv-pt@v0.1",
+        "language": {
+            "name": "Portuguese (Portugal)",
+            "code": "pt-PT",
+            "gender": "male"
+        },
+        "sentence": "Um arco-íris é um fenômeno óptico e meteorológico que "
+                    "separa a luz do sol em seu espectro contínuo quando o "
+                    "sol brilha sobre gotículas de água suspensas no ar.",
     },
     "bg": {
-        "model": "neongeckocom/tts-vits-cv-bg@v0.1", 
-        "sentence": "Дъга е оптично и метеорологично явление, свързано с появата в небето на почти непрекъснат спектър на светлината.",
+        "model": "neongeckocom/tts-vits-cv-bg@v0.1",
+        "language": {
+            "name": "Bulgarian",
+            "code": "bg-BG",
+            "gender": "female"
+        },
+        "sentence": "Дъга е оптично и метеорологично явление, свързано с "
+                    "появата в небето на почти непрекъснат спектър на "
+                    "светлината.",
     },
     "hr": {
-        "model": "neongeckocom/tts-vits-cv-hr@v0.1", 
-        "sentence": "Duga je česta optička pojava u Zemljinoj atmosferi u obliku jednog ili više obojenih kružnih lukova, koja nastaje jednostrukim ili višestrukim lomom i odbijanjem zraka svjetlosti u kapljicama kiše.",
+        "model": "neongeckocom/tts-vits-cv-hr@v0.1",
+        "language": {
+            "name": "Hungarian",
+            "code": "hr-HU",
+            "gender": "female"
+        },
+        "sentence": "Duga je česta optička pojava u Zemljinoj atmosferi u "
+                    "obliku jednog ili više obojenih kružnih lukova, koja "
+                    "nastaje jednostrukim ili višestrukim lomom i odbijanjem "
+                    "zraka svjetlosti u kapljicama kiše.",
     },
     "da": {
-        "model": "neongeckocom/tts-vits-cv-da@v0.1", 
-        "sentence": "En regnbue er et optisk fænomen; en lyseffekt, som skabes på himlen, når lys fra Solen rammer små vanddråber i luften, f.eks. faldende regn.",
+        "model": "neongeckocom/tts-vits-cv-da@v0.1",
+        "language": {
+            "name": "Danish",
+            "code": "da-DK",
+            "gender": "female"
+        },
+        "sentence": "En regnbue er et optisk fænomen; en lyseffekt, som "
+                    "skabes på himlen, når lys fra Solen rammer små "
+                    "vanddråber i luften, f.eks. faldende regn.",
     },
     "sk": {
-        "model": "neongeckocom/tts-vits-cv-sk@v0.1", 
-        "sentence": "Dúha je optický úkaz vznikajúci v atmosfére Zeme. Vznik dúhy je spôsobený disperziou slnečného svetla prechádzajúceho kvapkou.",
+        "model": "neongeckocom/tts-vits-cv-sk@v0.1",
+        "language": {
+            "name": "Slovak",
+            "code": "sk-SK",
+            "gender": "female"
+        },
+        "sentence": "Dúha je optický úkaz vznikajúci v atmosfére Zeme. Vznik "
+                    "dúhy je spôsobený disperziou slnečného svetla "
+                    "prechádzajúceho kvapkou.",
     },
     "fi": {
-        "model": "neongeckocom/tts-vits-css10-fi@v0.1", 
-        "sentence": "Sateenkaari on spektrin väreissä esiintyvä ilmakehän optinen ilmiö. Se syntyy, kun valo taittuu pisaran etupinnasta.",
+        "model": "neongeckocom/tts-vits-css10-fi@v0.1",
+        "language": {
+            "name": "Finnish",
+            "code": "fi-FI",
+            "gender": "male"
+        },
+        "sentence": "Sateenkaari on spektrin väreissä esiintyvä ilmakehän "
+                    "optinen ilmiö. Se syntyy, kun valo taittuu pisaran "
+                    "etupinnasta.",
     },
     "lt": {
-        "model": "neongeckocom/tts-vits-cv-lt@v0.1", 
-        "sentence": "Vaivorykštė - optinis ir meteorologinis reiškinys, kuomet Saulei apšvietus atmosferoje esančius vandens lašelius, danguje atsiranda ištisinė spalvų spektro juosta.",
+        "model": "neongeckocom/tts-vits-cv-lt@v0.1",
+        "language": {
+            "name": "Lithuanian",
+            "code": "lt-LT",
+            "gender": "female"
+        },
+        "sentence": "Vaivorykštė - optinis ir meteorologinis reiškinys, "
+                    "kuomet Saulei apšvietus atmosferoje esančius vandens "
+                    "lašelius, danguje atsiranda ištisinė spalvų spektro "
+                    "juosta.",
     },
     "sl": {
-        "model": "neongeckocom/tts-vits-cv-sl@v0.1", 
-        "sentence": "Mavrica je svetlobni pojav v ozračju, ki ga vidimo v obliki loka spektralnih barv. Nastane zaradi loma, disperzije in odboja sončnih žarkov v vodnih kapljicah v zraku. Mavrica, ki nastane zaradi sončnih žarkov, se vedno pojavi na nasprotni strani od Sonca, tako da ima opazovalec Sonce vedno za hrbtom.",
+        "model": "neongeckocom/tts-vits-cv-sl@v0.1",
+        "language": {
+            "name": "Slovenian",
+            "code": "sl-SI",
+            "gender": "female"
+        },
+        "sentence": "Mavrica je svetlobni pojav v ozračju, ki ga vidimo v "
+                    "obliki loka spektralnih barv. Nastane zaradi loma, "
+                    "disperzije in odboja sončnih žarkov v vodnih kapljicah v "
+                    "zraku. Mavrica, ki nastane zaradi sončnih žarkov, se "
+                    "vedno pojavi na nasprotni strani od Sonca, tako da ima "
+                    "opazovalec Sonce vedno za hrbtom.",
     },
     "lv": {
-        "model": "neongeckocom/tts-vits-cv-lv@v0.1", 
-        "sentence": "Varavīksne ir optiska parādība atmosfērā, kuru rada Saules staru laušana un atstarošana krītošos lietus pilienos. Tā parādās iepretim Saulei uz mākoņu fona, kad līst. Varavīksnes loks pāri debesjumam ir viens no krāšņākajiem dabas skatiem. Pārējās krāsas izvietojušās atbilstoši tā loka gammai.",
+        "model": "neongeckocom/tts-vits-cv-lv@v0.1",
+        "language": {
+            "name": "Latvian",
+            "code": "lv-LV",
+            "gender": "female"
+        },
+        "sentence": "Varavīksne ir optiska parādība atmosfērā, kuru rada "
+                    "Saules staru laušana un atstarošana krītošos lietus "
+                    "pilienos. Tā parādās iepretim Saulei uz mākoņu fona, kad "
+                    "līst. Varavīksnes loks pāri debesjumam ir viens no "
+                    "krāšņākajiem dabas skatiem. Pārējās krāsas izvietojušās "
+                    "atbilstoši tā loka gammai.",
     },
     "et": {
-        "model": "neongeckocom/tts-vits-cv-et@v0.1", 
-        "sentence": "Vikerkaare põhjustab päikesekiirte eri lainepikkustel erinev murdumine ja peegeldumine ligikaudu kerakujulistelt vihmapiiskadelt vihmaseinal või vihmapilves, kui päikesevalgus langeb piiskadele vaatleja selja tagant.",
+        "model": "neongeckocom/tts-vits-cv-et@v0.1",
+        "language": {
+            "name": "Estonian",
+            "code": "et-EE",
+            "gender": "female"
+        },
+        "sentence": "Vikerkaare põhjustab päikesekiirte eri lainepikkustel "
+                    "erinev murdumine ja peegeldumine ligikaudu "
+                    "kerakujulistelt vihmapiiskadelt vihmaseinal või "
+                    "vihmapilves, kui päikesevalgus langeb piiskadele "
+                    "vaatleja selja tagant.",
     },
     "ga": {
-        "model": "neongeckocom/tts-vits-cv-ga@v0.2", 
-        "sentence": "Do réir lucht na heolaíochta, is é solas na gréine ag taitneamh ar bhraonta báistí sa spéir faoi ndearna an tuar ceatha. Dar linne ná tagann ón ngréin ach aon tsolais amháin, ach ní mar sin atá.",
+        "model": "neongeckocom/tts-vits-cv-ga@v0.2",
+        "language": {
+            "name": "Irish (Gaelic)",
+            "code": "ga-IE",
+            "gender": "female"
+        },
+        "sentence": "Do réir lucht na heolaíochta, is é solas na gréine ag "
+                    "taitneamh ar bhraonta báistí sa spéir faoi ndearna an "
+                    "tuar ceatha. Dar linne ná tagann ón ngréin ach aon "
+                    "tsolais amháin, ach ní mar sin atá.",
     },
     "mt": {
-        "model": "neongeckocom/tts-vits-cv-mt@v0.1", 
-        "sentence": "Qawsalla hija fenomenu meteoroloġiku li huwa kkawżat minn riflessjoni, rifrazzjoni u tixrid ta 'dawl fi qtar ta' l-ilma li jirriżulta fi spettru ta 'dawl li jidher fis-sema.",
+        "model": "neongeckocom/tts-vits-cv-mt@v0.1",
+        "language": {
+            "name": "Maltese",
+            "code": "mt-MT",
+            "gender": "female"
+        },
+        "sentence": "Qawsalla hija fenomenu meteoroloġiku li huwa kkawżat "
+                    "minn riflessjoni, rifrazzjoni u tixrid ta 'dawl fi qtar "
+                    "ta' l-ilma li jirriżulta fi spettru ta 'dawl li jidher "
+                    "fis-sema.",
     },
 }
+
+tts_config = {config['language']['code']: [
+    {
+        'lang': config['language']['code'],
+        'display_name': f'{config["language"]["name"]} '
+                        f'({config["language"]["gender"]})',
+        'offline': True
+    }
+] for config in languages.values()}

--- a/neon_tts_plugin_coqui/configs.py
+++ b/neon_tts_plugin_coqui/configs.py
@@ -325,8 +325,8 @@ languages = {
 tts_config = {config['language']['code']: [
     {
         'lang': config['language']['code'],
-        'display_name': f'{config["language"]["name"]} '
-                        f'({config["language"]["gender"]})',
+        'display_name': f'{config["language"]["name"]}',
+        'gender': config["language"]["gender"],
         'offline': True
     }
 ] for config in languages.values()}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ def get_requirements(requirements_filename: str):
 
 
 PLUGIN_ENTRY_POINT = 'coqui = neon_tts_plugin_coqui:CoquiTTS'
+CONFIG_ENTRY_POINT = 'coqui.config = neon_tts_plugin_coqui.configs:tts_config'
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -81,5 +82,6 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords='mycroft plugin tts',
-    entry_points={'mycroft.plugin.tts': PLUGIN_ENTRY_POINT}
+    entry_points={'mycroft.plugin.tts': PLUGIN_ENTRY_POINT,
+                  'mycroft.plugin.tts.config': CONFIG_ENTRY_POINT}
 )

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -128,5 +128,27 @@ class TestTTS(unittest.TestCase):
         self.assertEqual(self.tts.available_languages, supported_langs)
 
 
+class TestConfigs(unittest.TestCase):
+    def test_languages(self):
+        from neon_tts_plugin_coqui.configs import languages
+        self.assertIsInstance(languages, dict)
+        for lang in languages:
+            self.assertEqual(set(languages[lang].keys()),
+                             {'model', 'language', 'sentence'})
+            self.assertIsInstance(languages[lang]['model'], str)
+            self.assertIsInstance(languages[lang]['language'], dict)
+            self.assertIsInstance(languages[lang]['sentence'], str)
+
+    def test_tts_config(self):
+        from neon_tts_plugin_coqui.configs import languages, tts_config
+        self.assertEqual(len(languages), len(tts_config))
+        for lang, configs in tts_config:
+            self.assertIsInstance(configs, list)
+            for config in configs:
+                self.assertEqual(config['lang'], lang)
+                self.assertIsInstance(config['display_name'], str)
+                self.assertTrue(config['offline'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -142,7 +142,7 @@ class TestConfigs(unittest.TestCase):
     def test_tts_config(self):
         from neon_tts_plugin_coqui.configs import languages, tts_config
         self.assertEqual(len(languages), len(tts_config))
-        for lang, configs in tts_config:
+        for lang, configs in tts_config.items():
             self.assertIsInstance(configs, list)
             for config in configs:
                 self.assertEqual(config['lang'], lang)


### PR DESCRIPTION
Adds more information to `languages` config to support the [config entrypoint](https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/71) used to populate options in the [setup skill](https://github.com/OpenVoiceOS/skill-ovos-setup)