### PR TITLE
Handle connection errors and fall back to local cached model files

### DIFF
--- a/neon_tts_plugin_coqui/__init__.py
+++ b/neon_tts_plugin_coqui/__init__.py
@@ -254,7 +254,14 @@ class CoquiTTS(TTS):
         model_name, *suffix = model_name.split("@")
         revision = dict(enumerate(suffix)).get(0, None)
 
-        model_path = hf_hub_download(model_name, "model.pt", revision=revision)
+        try:
+            model_path = hf_hub_download(model_name, "model.pt",
+                                         revision=revision)
+        except ConnectionError as e:
+            LOG.error(e)
+            model_path = hf_hub_download(model_name, "model.pt",
+                                         revision=revision,
+                                         local_files_only=True)
 
         return model_path
 


### PR DESCRIPTION
# Description
Explicitly handle connection errors with fallback to local cached files

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This is an observed bug on Mark2 installations when a download is attempted before ntp sync is completed but other connection errors are possible